### PR TITLE
Added line-profiler

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,5 +26,10 @@ dependencies:
     - newspaper3k==0.2.8
     - pytrec-eval-terrier==0.5.2
     - ffmpeg==1.4
+    - codecarbon==2.1.4
     - bitermplus==0.6.10 #install it if you want to use btm model in the topic modeling layer
+    - line-profiler==4.0.0
+    - torch==1.10.2
+    - torchmetrics==0.8.2
+    - params==0.9.0
 #gsdmm==0.1 #install it if you want to use gsdmm model in the topic modeling layer, from github repo at https://github.com/rwalk/gsdmm.git

--- a/readme.md
+++ b/readme.md
@@ -192,6 +192,8 @@ where the input arguements are:
 
 `-g`: A list of graph embedding methods among {`AE`, `DynAE`, `DynRNN`, `DynAERNN`}, required, case-insensitive.
 
+`-p`: A flag for the run to be time-profiled, optional.
+
 
 
 A run will produce an output folder at `./output/{r}` and subfolders for each topic modeling and graph embedding pair as baselines, e.g., `lda.AE`, `lda.DynAE`, and `lda.DynAERNN`. The final evaluation results are aggregated in `./output/{r}/pred.eval.mean.csv`. See an example run on toy dataset at [`./output/toy`](./output/toy). 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,6 @@ ffmpeg==1.4
 codecarbon==2.1.4
 bitermplus==0.6.10 #install it if you want to use btm model in the topic modeling layer
 line-profiler==4.0.0
+torch==1.10.2
+torchmetrics==0.8.2
+params==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ pytrec-eval-terrier==0.5.2
 ffmpeg==1.4
 codecarbon==2.1.4
 bitermplus==0.6.10 #install it if you want to use btm model in the topic modeling layer
+line-profiler==4.0.0

--- a/src/main.py
+++ b/src/main.py
@@ -201,6 +201,19 @@ def addargs(parser):
     baseline.add_argument('-t', '--tml-method-list', nargs='+', type=str.lower, required=True, help='a list of topic modeling methods (eg. -t LDA)')
     baseline.add_argument('-g', '--gel-method-list', nargs='+', type=str.lower, required=True, help='a list of graph embedding methods (eg. -g DynAERNN)')
     baseline.add_argument('-r', '--run-desc', type=str.lower, required=True, help='a unique description for the run (eg. -r toy')
+    baseline.add_argument('-p', '--profile-time', action='store_true', required=False, help='an indicator to line profile the program')
+
+def tprofile(args):
+    from line_profiler import LineProfiler
+    profiler = LineProfiler()
+    # add functions to profile
+    profiler(main)
+    profiler.enable_by_count()
+    run(tml_baselines=args.tml_method_list, gel_baselines=args.gel_method_list, run_desc=args.run_desc)
+    # convert to text format
+    with open(f'../output/{args.run_desc}/LineProfile.txt', 'w') as f:
+        print(f'Profiling for {args.tml_method_list} and {args.gel_method_list} ....', file=f)
+        profiler.print_stats(stream=f)
 
 # python -u main.py -r toy -t LdA.GeNsim -g Ae DynAe DynaERnN
 if __name__ == '__main__':
@@ -209,6 +222,9 @@ if __name__ == '__main__':
     args = parser.parse_args()
     if not os.path.isdir(f'../output/{args.run_desc}'): os.makedirs(f'../output/{args.run_desc}')
     cmn.logger = cmn.LogFile(f'../output/{args.run_desc}/Log.txt')
-    run(tml_baselines=args.tml_method_list, gel_baselines=args.gel_method_list, run_desc=args.run_desc)
+    if args.profile_time:
+        tprofile(args)
+    else:
+        run(tml_baselines=args.tml_method_list, gel_baselines=args.gel_method_list, run_desc=args.run_desc)
     aggregate(f'../output/{args.run_desc}')
     remove_files()

--- a/src/main.py
+++ b/src/main.py
@@ -207,7 +207,8 @@ def tprofile(args):
     from line_profiler import LineProfiler
     profiler = LineProfiler()
     # add functions to profile
-    profiler(main)
+    # profiler(run) # profiles the carbon tracker and logging calls in run()
+    profiler(main)  # profiles the execution of the pipeline
     profiler.enable_by_count()
 
     # runs profiling for each combination since they employ different function calls

--- a/src/main.py
+++ b/src/main.py
@@ -209,11 +209,17 @@ def tprofile(args):
     # add functions to profile
     profiler(main)
     profiler.enable_by_count()
-    run(tml_baselines=args.tml_method_list, gel_baselines=args.gel_method_list, run_desc=args.run_desc)
-    # convert to text format
-    with open(f'../output/{args.run_desc}/LineProfile.txt', 'w') as f:
-        print(f'Profiling for {args.tml_method_list} and {args.gel_method_list} ....', file=f)
-        profiler.print_stats(stream=f)
+
+    # runs profiling for each combination since they employ different function calls
+    tml_baselines = args.tml_method_list
+    gel_baselines = args.gel_method_list
+    for t in tml_baselines:
+        for g in gel_baselines:
+            run(tml_baselines=[t], gel_baselines=[g], run_desc=args.run_desc)
+            # convert to text format in the respective baseline folders
+            with open(f'../output/{args.run_desc}/{t}.{g}/TimeProfile.txt', 'w') as f:
+                print(f'Profiling for {t} and {g} ....', file=f)
+                profiler.print_stats(stream=f)
 
 # python -u main.py -r toy -t LdA.GeNsim -g Ae DynAe DynaERnN
 if __name__ == '__main__':


### PR DESCRIPTION
From what I've read, line_profiler adds a bit of overhead to the execution process. As such, I added a flag to the command line arguments so that time is only profiled when users input as such.

So far, line_profiler can only profile the specified function if it's within the file that the profiler is in. I'm currently looking through documentations for ways that might be able to bypass this limitation.